### PR TITLE
removes all explicit dependencies between roles

### DIFF
--- a/roles/adr/meta/main.yml
+++ b/roles/adr/meta/main.yml
@@ -12,9 +12,3 @@ galaxy_info:
       versions:
         - 20.04
   galaxy_tags: []
-
-# Although technically, adr needs neither base or java to install, JAVA_HOME needs to be set in order for the app to
-# be able to run.
-dependencies:
-  - role: base
-  - role: java

--- a/roles/ansible/meta/main.yml
+++ b/roles/ansible/meta/main.yml
@@ -12,6 +12,3 @@ galaxy_info:
       versions:
         - 20.04
   galaxy_tags: []
-
-dependencies:
-  - role: base

--- a/roles/arcanist/meta/main.yml
+++ b/roles/arcanist/meta/main.yml
@@ -13,7 +13,3 @@ galaxy_info:
         - 20.04
         - 22.04
   galaxy_tags: []
-
-dependencies:
-  - role: base
-  - role: git

--- a/roles/docker/meta/main.yml
+++ b/roles/docker/meta/main.yml
@@ -12,6 +12,3 @@ galaxy_info:
       versions:
         - 20.04
   galaxy_tags: []
-
-dependencies:
-  - role: base

--- a/roles/git/meta/main.yml
+++ b/roles/git/meta/main.yml
@@ -12,6 +12,3 @@ galaxy_info:
       versions:
         - 20.04
   galaxy_tags: []
-
-dependencies:
-  - role: base

--- a/roles/git_utils/meta/main.yml
+++ b/roles/git_utils/meta/main.yml
@@ -12,6 +12,3 @@ galaxy_info:
       versions:
         - 20.04
   galaxy_tags: []
-
-dependencies:
-  - role: base

--- a/roles/java/meta/main.yml
+++ b/roles/java/meta/main.yml
@@ -12,6 +12,3 @@ galaxy_info:
       versions:
         - 20.04
   galaxy_tags: []
-
-dependencies:
-  - role: base

--- a/roles/kotlin/meta/main.yml
+++ b/roles/kotlin/meta/main.yml
@@ -12,6 +12,3 @@ galaxy_info:
       versions:
         - 20.04
   galaxy_tags: []
-
-dependencies:
-  - role: base

--- a/roles/linters/meta/main.yml
+++ b/roles/linters/meta/main.yml
@@ -12,7 +12,3 @@ galaxy_info:
       versions:
         - 20.04
   galaxy_tags: []
-
-dependencies:
-  - role: base
-  - role: java

--- a/roles/molecule/meta/main.yml
+++ b/roles/molecule/meta/main.yml
@@ -12,9 +12,3 @@ galaxy_info:
       versions:
         - 20.04
   galaxy_tags: []
-
-dependencies:
-  - role: base
-  - role: python
-  - role: ansible
-  - role: docker

--- a/roles/node/meta/main.yml
+++ b/roles/node/meta/main.yml
@@ -12,6 +12,3 @@ galaxy_info:
       versions:
         - 20.04
   galaxy_tags: []
-
-dependencies:
-  - role: base

--- a/roles/python/meta/main.yml
+++ b/roles/python/meta/main.yml
@@ -12,6 +12,3 @@ galaxy_info:
       versions:
         - 20.04
   galaxy_tags: []
-
-dependencies:
-  - role: base


### PR DESCRIPTION
I want this change because I want to be able to use some of the roles while not having to invoke base. I removed all explicit dependencies since that allows people/teams to just "pick and choose" whatever roles are relevant for them.

Up for discussion!