### PR TITLE
change name from ansible_collection_wsl to wsl

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 ---
 namespace: elhub
-name: ansible_collection_wsl
+name: wsl
 version: 1.0.0-SNAPSHOT
 readme: README.md
 authors:


### PR DESCRIPTION
this allows for "cleaner" references to roles

e.g. elhub.wsl.vault over elhub.ansible_collection_vault

NOTE: This is a breaking change